### PR TITLE
GitStatus Fixes for Bash

### DIFF
--- a/bash/lib/gitstatus
+++ b/bash/lib/gitstatus
@@ -10,11 +10,10 @@ fi
 read -ra HOST_ARRAY <<< `git remote -v | grep fetch `;
 host=`echo "${HOST_ARRAY[1]}" | cut -d'/' -f3`
 
-
-if [[ ! -e .gitfetch ]] || [[ -e .gitfetch && `date "+%Y%m%d%H%M"` -ge $(cat .gitfetch)+5 ]]; then
+if [[ ! -e .gitfetch ]] || [[ -e .gitfetch ]] && [[ `date "+%Y%m%d%H%M"` -ge $(($(cat .gitfetch)+5)) ]]; then
   online=true;
 
-  ping -t 2 $host 2> /dev/null;
+  ping -t 2 $host 2>&1 /dev/null;
   if [[ $? -ne 0 ]]; then
     online=false;
     date "+%Y%m%d%H%M" > .gitfetch


### PR DESCRIPTION
**Description:** <!-- Quickly describe what you are solving and how -->
`gitstatus` command was not working properly on the Mac Mini using bash when I installed this repo. This PR contains changes that make sure git status works again.

Tested on my Macbook Pro as well

Also tested on Windows computer

**Related:** <!-- Links to Related issues or documentation/references used for this change -->
N/A

**Visual:** <!-- Add a screenshot! -->
N/A

**TODO:**
 ~- [ ] Updated README documents~
 - [x] Complete PR Body
